### PR TITLE
Added Dockerfile for quick launch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+###################################
+# Jinja2 live parser Dockerfile
+#
+# Version: 0.1
+# Author:  Sonu K. Meena(sahilsk)<sonukr666@gmail.com >
+###################################
+
+# Pull base image.
+FROM python:2.7
+
+RUN git clone https://github.com/sahilsk/jinja2-live-parser.git /data
+
+WORKDIR /data
+
+# Install dependencies
+RUN pip install -r requirements.txt
+
+# Change bind host
+RUN  sed -i 's/\(.*\)app.run()/\1app.run(host="0.0.0.0")/'  parser.py
+
+# Expose port to Host
+EXPOSE 5000
+
+# Define default command.
+CMD ["python", "parser.py"]

--- a/README.md
+++ b/README.md
@@ -10,6 +10,16 @@ All you need is Python and preferably [pip](https://pypi.python.org/pypi/pip).
     $ pip install -r requirements.txt
     $ python parser.py
 
+## Or through Dockerfile
+
+#### Build
+    
+    docker build -t mydocker/j2parser .
+    docker run -d -p 49153:5000 mydocker/j2parser
+
+Or simply `pull` it from registry (without building)
+
+    docker run -d -p 49153:5000 sahilsk/j2parser
 
 ## Usage 
 
@@ -19,3 +29,4 @@ You are all set, go to `http://localhost:5000/` and have fun.
 ## Preview
 
 ![preview](http://i.imgur.com/9tSiilb.png)
+


### PR DESCRIPTION
The tool is really handy. I use to for testing conditions while writing Ansible playbooks.
With dockerfile i can simply launch it and use it wherever and whenver i need it.

Hence, i wrote a small dockerfile for making the application run on docker quickly.

I've also added instructions on building dockerfile locally or running dockerfile directly from docker registry.